### PR TITLE
Fix error in combination rule logic

### DIFF
--- a/molo/surveys/static/js/survey-admin.js
+++ b/molo/surveys/static/js/survey-admin.js
@@ -100,7 +100,7 @@ $(function(){
     $.each(ruleIndex, function(index_outer, form){
       $.each(form.blockIds, function(index_inner, value) {
         ruleValueTextPairs.push({
-          "value": form.ruleName.replace(" ", "") + "_" + String(index_inner),
+          "value": form.ruleName.replace(/ /g, "") + "_" + String(index_inner),
           "text": form.ruleName + " " + String(index_inner + 1),
         });
       });


### PR DESCRIPTION
`.replace(" ", "")` will replace _only_ the first instance of whitespace
`.replace(/ /g, "")` will replace _all_ of the instances of whitespace