### PR TITLE
Update Combination Rule to handle single nested block

### DIFF
--- a/molo/surveys/adapters.py
+++ b/molo/surveys/adapters.py
@@ -90,7 +90,9 @@ def evaluate(list_):
     Sample Input:
 
     '''
-    if len(list_) == 3:
+    if len(list_) == 1 and isinstance(list_[0], list):
+        return evaluate(list_[0])
+    elif len(list_) == 3:
         operator = list_[1]
         first = list_[0] if isinstance(list_[0], bool) else evaluate(list_[0])
         second = list_[2] if isinstance(list_[2], bool) else evaluate(list_[2])

--- a/molo/surveys/rules.py
+++ b/molo/surveys/rules.py
@@ -407,7 +407,7 @@ class CombinationRule(AbstractBaseRule):
                 if newData[0] == 'NestedLogic':
                     pass
                 else:
-                    raise StreamBlockValidationError(non_block_errors = [_(
+                    raise StreamBlockValidationError(non_block_errors=[_(
                         'Rule Combination must follow the <Rule/NestedLogic> '
                         '<Operator> <Rule/NestedLogic> pattern.')])
             else:
@@ -419,12 +419,13 @@ class CombinationRule(AbstractBaseRule):
 
                     if not (
                         (newData[first_rule_index] == 'Rule' or
-                        newData[first_rule_index] == 'NestedLogic') and
+                         newData[first_rule_index] == 'NestedLogic') and
                         (newData[operator_index] == 'Operator') and
                         (newData[second_rule_index] == 'Rule' or
                             newData[second_rule_index] == 'NestedLogic')):
                         raise StreamBlockValidationError(non_block_errors=[_(
-                            'Rule Combination must follow the <Rule/NestedLogic> '
+                            'Rule Combination must follow the '
+                            '<Rule/NestedLogic> '
                             '<Operator> <Rule/NestedLogic> pattern.')])
         else:
             raise StreamBlockValidationError(non_block_errors=[_(

--- a/molo/surveys/rules.py
+++ b/molo/surveys/rules.py
@@ -398,26 +398,34 @@ class CombinationRule(AbstractBaseRule):
             elif isinstance(self.body.stream_data[0], tuple):
                 newData = [block[0] for block in self.body.stream_data]
 
-            if len(newData) == 1 or (len(newData) - 1) % 2 != 0:
+            if (len(newData) - 1) % 2 != 0:
                 raise StreamBlockValidationError(non_block_errors=[_(
                     'Rule Combination must follow the <Rule/NestedLogic>'
                     '<Operator> <Rule/NestedLogic> pattern.')])
 
-            iterations = (len(newData) - 1) / 2
-            for i in range(iterations):
-                first_rule_index = i * 2
-                operator_index = (i * 2) + 1
-                second_rule_index = (i * 2) + 2
-
-                if not (
-                    (newData[first_rule_index] == 'Rule' or
-                     newData[first_rule_index] == 'NestedLogic') and
-                    (newData[operator_index] == 'Operator') and
-                    (newData[second_rule_index] == 'Rule' or
-                        newData[second_rule_index] == 'NestedLogic')):
-                    raise StreamBlockValidationError(non_block_errors=[_(
+            if len(newData) == 1:
+                if newData[0] == 'NestedLogic':
+                    pass
+                else:
+                    raise StreamBlockValidationError(non_block_errors = [_(
                         'Rule Combination must follow the <Rule/NestedLogic> '
                         '<Operator> <Rule/NestedLogic> pattern.')])
+            else:
+                iterations = (len(newData) - 1) / 2
+                for i in range(iterations):
+                    first_rule_index = i * 2
+                    operator_index = (i * 2) + 1
+                    second_rule_index = (i * 2) + 2
+
+                    if not (
+                        (newData[first_rule_index] == 'Rule' or
+                        newData[first_rule_index] == 'NestedLogic') and
+                        (newData[operator_index] == 'Operator') and
+                        (newData[second_rule_index] == 'Rule' or
+                            newData[second_rule_index] == 'NestedLogic')):
+                        raise StreamBlockValidationError(non_block_errors=[_(
+                            'Rule Combination must follow the <Rule/NestedLogic> '
+                            '<Operator> <Rule/NestedLogic> pattern.')])
         else:
             raise StreamBlockValidationError(non_block_errors=[_(
                 'Rule Combination must follow the <Rule/NestedLogic>'

--- a/molo/surveys/tests/test_adapters.py
+++ b/molo/surveys/tests/test_adapters.py
@@ -34,6 +34,10 @@ class TestAdapterUtils(TestCase, MoloTestCaseMixin):
 
         self.request.user.segment_groups.add(self.group_1)
 
+        self.group_rule_1 = GroupMembershipRule(group=self.group_1)
+        self.group_rule_2 = GroupMembershipRule(group=self.group_2)
+        self.logged_in_rule = UserIsLoggedInRule(is_logged_in=True)
+
     def test_get_rule(self):
         fake_ds = {
             'TimeRule': ['first time rule', 'second time rule'],
@@ -48,14 +52,12 @@ class TestAdapterUtils(TestCase, MoloTestCaseMixin):
                          fake_ds["UserIsLoggedInRule"][0])
 
     def test_index_rules_by_type(self):
-        group_rule_1 = GroupMembershipRule(group=self.group_1)
-        group_rule_2 = GroupMembershipRule(group=self.group_2)
-        logged_in_rule = UserIsLoggedInRule(is_logged_in=True)
-
-        test_input = [logged_in_rule, group_rule_1, group_rule_2]
+        test_input = [self.logged_in_rule,
+                      self.group_rule_1,
+                      self.group_rule_2]
         expected_output = {
-            'GroupMembershipRule': [group_rule_1, group_rule_2],
-            'UserIsLoggedInRule': [logged_in_rule]
+            'GroupMembershipRule': [self.group_rule_1, self.group_rule_2],
+            'UserIsLoggedInRule': [self.logged_in_rule]
         }
 
         self.assertEqual(
@@ -63,10 +65,6 @@ class TestAdapterUtils(TestCase, MoloTestCaseMixin):
             expected_output)
 
     def test_transform_into_boolean_list_simple(self):
-        group_rule_1 = GroupMembershipRule(group=self.group_1)
-        group_rule_2 = GroupMembershipRule(group=self.group_2)
-        logged_in_rule = UserIsLoggedInRule(is_logged_in=True)
-
         sample_stream_data = [
             {u'type': u'Rule', u'value': u'UserIsLoggedInRule_0'},
             {u'type': u'Operator', u'value': u'and'},
@@ -80,8 +78,8 @@ class TestAdapterUtils(TestCase, MoloTestCaseMixin):
         ]
 
         sample_indexed_rules = {
-            'GroupMembershipRule': [group_rule_1, group_rule_2],
-            'UserIsLoggedInRule': [logged_in_rule]
+            'GroupMembershipRule': [self.group_rule_1, self.group_rule_2],
+            'UserIsLoggedInRule': [self.logged_in_rule]
         }
 
         self.assertEqual(
@@ -90,12 +88,41 @@ class TestAdapterUtils(TestCase, MoloTestCaseMixin):
                 sample_indexed_rules,
                 self.request
             ),
-            [logged_in_rule.test_user(self.request),
+            [self.logged_in_rule.test_user(self.request),
              u'and',
              [
-                group_rule_1.test_user(self.request),
+                self.group_rule_1.test_user(self.request),
                 u'or',
-                group_rule_2.test_user(self.request)
+                self.group_rule_2.test_user(self.request)
+            ]]
+        )
+
+    def test_transform_into_boolean_list_only_nested(self):
+        sample_stream_data = [
+            {
+                u'type': u'NestedLogic',
+                u'value': {
+                    u'operator': u'or',
+                    u'rule_1': u'UserIsLoggedInRule_0',
+                    u'rule_2': u'GroupMembershipRule_0'}
+            }
+        ]
+
+        sample_indexed_rules = {
+            'GroupMembershipRule': [self.group_rule_1],
+            'UserIsLoggedInRule': [self.logged_in_rule]
+        }
+
+        self.assertEqual(
+            transform_into_boolean_list(
+                sample_stream_data,
+                sample_indexed_rules,
+                self.request
+            ),
+            [[
+                self.logged_in_rule.test_user(self.request),
+                u'or',
+                self.group_rule_1.test_user(self.request)
             ]]
         )
 

--- a/molo/surveys/tests/test_adapters.py
+++ b/molo/surveys/tests/test_adapters.py
@@ -150,3 +150,10 @@ class TestAdapterUtils(TestCase, MoloTestCaseMixin):
                  [False, "and", False], "or",
                  [True, 'and', False]])
         )
+
+    def test_evaluate_8(self):
+        self.assertEqual(
+            ((False or True)),
+            evaluate(
+                [[False, "or", True]])
+        )


### PR DESCRIPTION
This updates the combination rule so that the user can submit a sinle nested block, should they wish to do so. 

Although the user can represent this logic in a different way, it was decided that this use case should be considered.