### PR TITLE
Use questions answered number to obtain a question number

### DIFF
--- a/molo/surveys/templates/surveys/molo_survey_page.html
+++ b/molo/surveys/templates/surveys/molo_survey_page.html
@@ -16,6 +16,15 @@
         {% csrf_token %}
         {{ form.media }}
         {% for field in form %}
+          {% if fields_step %}
+            <h4 class="surveys__question-title">
+              Question {{ fields_step.paginator.answered|length|add:forloop.counter }}
+            </h4>
+          {% else %}
+            <h4 class="surveys__question-title">
+              Question {{ forloop.counter }}
+            </h4>
+          {% endif %}
           <fieldset>
               <div class="input-group">
                 <label for="{{ field.id_for_label }}">{{ field.label }}</label>


### PR DESCRIPTION
Also, as an alternative I'd suggest that if `fields_step` is not present, you could just display step number, i.e. page number.

To make this PR work with `molo-gem`, you must update `molo_survey_page.html` template within `molo-gem` too.