### PR TITLE
Mark Survey, group and article tag rules as static

### DIFF
--- a/molo/surveys/rules.py
+++ b/molo/surveys/rules.py
@@ -45,6 +45,8 @@ AbstractBaseRule.__subclasses__ = classmethod(__ordered_subclasses__)
 
 
 class SurveySubmissionDataRule(AbstractBaseRule):
+    static = True
+
     EQUALS = 'eq'
     CONTAINS = 'in'
 
@@ -239,6 +241,8 @@ class SurveySubmissionDataRule(AbstractBaseRule):
 
 
 class SurveyResponseRule(AbstractBaseRule):
+    static = True
+
     survey = models.ForeignKey('MoloSurveyPage',
                                verbose_name=_('survey'),
                                on_delete=models.CASCADE)
@@ -272,6 +276,8 @@ class SurveyResponseRule(AbstractBaseRule):
 
 class GroupMembershipRule(AbstractBaseRule):
     """wagtail-personalisation rule based on user's group membership."""
+    static = True
+
     group = models.ForeignKey('surveys.segmentusergroup')
 
     panels = [
@@ -297,6 +303,8 @@ class GroupMembershipRule(AbstractBaseRule):
 
 
 class ArticleTagRule(AbstractBaseRule):
+    static = True
+
     order = 410
     EQUALS = 'eq'
     GREATER_THAN = 'gt'

--- a/molo/surveys/tests/test_rules.py
+++ b/molo/surveys/tests/test_rules.py
@@ -74,6 +74,14 @@ class TestSurveyDataRuleSegmentation(TestCase, MoloTestCaseMixin):
 
         self.survey.refresh_from_db()
 
+    def test_survey_data_rule_is_static(self):
+        rule = SurveySubmissionDataRule(
+            survey=self.survey, operator=SurveySubmissionDataRule.EQUALS,
+            expected_response='super random text',
+            field_name=self.singleline_text.clean_name)
+
+        self.assertTrue(rule.static)
+
     def test_passing_string_rule_with_equal_operator(self):
         rule = SurveySubmissionDataRule(
             survey=self.survey, operator=SurveySubmissionDataRule.EQUALS,
@@ -215,6 +223,10 @@ class TestSurveyResponseRule(TestCase, MoloTestCaseMixin):
         submission.objects.create(user=user, page=survey,
                                   form_data=json.dumps(data))
 
+    def test_survey_response_rule_is_static(self):
+        rule = SurveyResponseRule(survey=self.survey)
+        self.assertTrue(rule.static)
+
     def test_user_not_submitted(self):
         rule = SurveyResponseRule(survey=self.survey)
         self.assertFalse(rule.test_user(self.request))
@@ -259,6 +271,10 @@ class TestGroupMembershipRuleSegmentation(TestCase, MoloTestCaseMixin):
         self.group = SegmentUserGroup.objects.create(name='Super Test Group!')
 
         self.request.user.segment_groups.add(self.group)
+
+    def test_group_membership_rule_is_static(self):
+        rule = GroupMembershipRule(group=self.group)
+        self.assertTrue(rule.static)
 
     def test_user_membership_rule_when_they_are_member(self):
         rule = GroupMembershipRule(group=self.group)
@@ -312,6 +328,10 @@ class TestArticleTagRuleSegmentation(TestCase, MoloTestCaseMixin):
                 page=new_article,
             )
         return new_article
+
+    def test_article_tag_rule_is_static(self):
+        rule = ArticleTagRule(tag=self.tag, count=1)
+        self.assertTrue(rule.static)
 
     def test_user_visits_page_with_tag(self):
         rule = ArticleTagRule(


### PR DESCRIPTION
The SurveySubmissionData, SurveyResponse, GroupMembership and ArticleTag rules are supposed to be static but it seems they were overlooked.