### PR TITLE
Test if user matches static segmentation rules even without an active request

### DIFF
--- a/local_test_settings.py
+++ b/local_test_settings.py
@@ -1,4 +1,4 @@
-from .base import *
+from .base import *  # noqa
 
 
 INSTALLED_APPS += (

--- a/molo/surveys/tests/test_rules.py
+++ b/molo/surveys/tests/test_rules.py
@@ -191,6 +191,20 @@ class TestSurveyDataRuleSegmentation(TestCase, MoloTestCaseMixin):
         self.request.user = AnonymousUser()
         self.assertFalse(rule.test_user(self.request))
 
+    def test_test_user_without_request(self):
+        rule = SurveySubmissionDataRule(
+            survey=self.survey, operator=SurveySubmissionDataRule.CONTAINS,
+            expected_response='er ra',
+            field_name=self.singleline_text.clean_name)
+        self.assertTrue(rule.test_user(None, self.request.user))
+
+    def test_test_user_without_user_or_request(self):
+        rule = SurveySubmissionDataRule(
+            survey=self.survey, operator=SurveySubmissionDataRule.CONTAINS,
+            expected_response='er ra',
+            field_name=self.singleline_text.clean_name)
+        self.assertFalse(rule.test_user(None))
+
 
 class TestSurveyResponseRule(TestCase, MoloTestCaseMixin):
     def setUp(self):
@@ -257,6 +271,16 @@ class TestSurveyResponseRule(TestCase, MoloTestCaseMixin):
         self.request.user = new_user
         self.assertTrue(rule.test_user(self.request))
 
+    def test_test_user_without_request(self):
+        self.submit_survey(self.survey, self.user)
+        rule = SurveyResponseRule(survey=self.survey)
+        self.assertTrue(rule.test_user(None, self.request.user))
+
+    def test_test_user_without_user_or_request(self):
+        self.submit_survey(self.survey, self.user)
+        rule = SurveyResponseRule(survey=self.survey)
+        self.assertFalse(rule.test_user(None))
+
 
 class TestGroupMembershipRuleSegmentation(TestCase, MoloTestCaseMixin):
     def setUp(self):
@@ -292,6 +316,14 @@ class TestGroupMembershipRuleSegmentation(TestCase, MoloTestCaseMixin):
         rule = GroupMembershipRule(group=self.group)
 
         self.assertFalse(rule.test_user(self.request))
+
+    def test_test_user_without_request(self):
+        rule = GroupMembershipRule(group=self.group)
+        self.assertTrue(rule.test_user(None, self.request.user))
+
+    def test_test_user_without_user_or_request(self):
+        rule = GroupMembershipRule(group=self.group)
+        self.assertFalse(rule.test_user(None))
 
 
 class TestArticleTagRuleSegmentation(TestCase, MoloTestCaseMixin):


### PR DESCRIPTION
Currently you can only test if a user matches a rule if they have an active session. This change allows us to also test using a User from the database.