### PR TITLE
Improve character count form fields

### DIFF
--- a/local_test_settings.py
+++ b/local_test_settings.py
@@ -1,4 +1,4 @@
-from .base import *  # noqa
+from .base import *  # noqa: F403
 
 
 INSTALLED_APPS += (

--- a/molo/surveys/forms.py
+++ b/molo/surveys/forms.py
@@ -5,8 +5,7 @@ from django import forms
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group
 from django.core.exceptions import ValidationError
-from django.forms.utils import ErrorList, flatatt
-from django.utils.encoding import force_text
+from django.forms.utils import ErrorList
 from django.utils.html import format_html
 from django.utils.translation import ugettext_lazy as _
 from django.utils import six
@@ -22,28 +21,22 @@ class CharacterCountWidget(forms.TextInput):
         js = ('js/widgets/character_count.js',)
 
     def render(self, name, value, attrs=None):
-        if value is None:
-            value = ''
-        final_attrs = self.build_attrs(attrs, type=self.input_type, name=name)
-        max_length = final_attrs['maxlength']
+        max_length = self.attrs['maxlength']
         maximum_text = _('Maximum: {max_length}').format(max_length=max_length)
-        if value != '':
-            # Only add the 'value' attribute if a value is non-empty.
-            final_attrs['value'] = force_text(self._format_value(value))
-        return format_html('<input {} /><span>{}</span>',
-                           flatatt(final_attrs),
-                           maximum_text)
+        return format_html(
+            u'{}<span>{}</span>',
+            super(CharacterCountWidget, self).render(name, value, attrs),
+            maximum_text,
+        )
 
 
 class MultiLineWidget(forms.Textarea):
     def render(self, name, value, attrs=None):
-        if value is None:
-            value = ''
-        final_attrs = self.build_attrs(attrs, name=name)
-        return format_html('<textarea{}>\r\n{}</textarea><span>{}</span>',
-                           flatatt(final_attrs),
-                           force_text(value),
-                           _('No limit'))
+        return format_html(
+            u'{}<span>{}</span>',
+            super(MultiLineWidget, self).render(name, value, attrs),
+            _('No limit'),
+        )
 
 
 class SurveysFormBuilder(FormBuilder):

--- a/molo/surveys/tests/test_forms.py
+++ b/molo/surveys/tests/test_forms.py
@@ -1,0 +1,32 @@
+from __future__ import unicode_literals
+
+from django.test import TestCase
+
+from molo.surveys.forms import CharacterCountWidget, MultiLineWidget
+
+
+class TestCharacterCountWidget(TestCase):
+    def test_character_count_widget_render(self):
+        widget = CharacterCountWidget()
+        html = widget.render('field-name', 'field-value', {'maxlength': 10})
+        self.assertEqual(
+            html,
+            ('<input  maxlength="10" name="field-name" '
+             'type="text" value="field-value" /><span>Maximum: 10</span>')
+        )
+
+    def test_character_count_widget_no_maxlength_raises_error(self):
+        widget = CharacterCountWidget()
+        with self.assertRaises(KeyError):
+            widget.render('field-name', 'field-value')
+
+
+class TestMultiLineWidget(TestCase):
+    def test_multi_line_widget_render(self):
+        widget = MultiLineWidget()
+        html = widget.render('field-name', 'field-value', {'my-attr': 1})
+        self.assertEqual(
+            html,
+            ('<textarea cols="40" my-attr="1" name="field-name" rows="10">'
+             '\r\nfield-value</textarea><span>No limit</span>')
+        )

--- a/molo/surveys/tests/test_forms.py
+++ b/molo/surveys/tests/test_forms.py
@@ -8,12 +8,9 @@ from molo.surveys.forms import CharacterCountWidget, MultiLineWidget
 class TestCharacterCountWidget(TestCase):
     def test_character_count_widget_render(self):
         widget = CharacterCountWidget()
-        html = widget.render('field-name', 'field-value', {'maxlength': 10})
-        self.assertEqual(
-            html,
-            ('<input  maxlength="10" name="field-name" '
-             'type="text" value="field-value" /><span>Maximum: 10</span>')
-        )
+        widget.attrs['maxlength'] = 10
+        html = widget.render('field-name', 'field-value')
+        self.assertTrue(html.endswith('<span>Maximum: 10</span>'))
 
     def test_character_count_widget_no_maxlength_raises_error(self):
         widget = CharacterCountWidget()
@@ -25,8 +22,4 @@ class TestMultiLineWidget(TestCase):
     def test_multi_line_widget_render(self):
         widget = MultiLineWidget()
         html = widget.render('field-name', 'field-value', {'my-attr': 1})
-        self.assertEqual(
-            html,
-            ('<textarea cols="40" my-attr="1" name="field-name" rows="10">'
-             '\r\nfield-value</textarea><span>No limit</span>')
-        )
+        self.assertTrue(html.endswith('<span>No limit</span>'))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,8 @@
-molo.core<7.0.0,>=6.3.1
+molo.core<7.0.0,>=6.5.0
 celery<4.0
 django-celery
 wagtailsurveys==0.1.1
 wagtail-personalisation-molo==0.10.5
-django==1.10.8
 psycopg2
 html5lib==0.9999999
 six==1.11.0


### PR DESCRIPTION
A lot of this code is just copied from the parent class so I think we can use the result of that render and then append some text that we care about.

This is beneficial because `build_attrs()` is technically a Django private API which breaks between 1.10 and 1.11.

https://docs.djangoproject.com/en/1.11/releases/1.11/#miscellaneous