### PR TITLE
Get user info from static rules

### DIFF
--- a/molo/surveys/rules.py
+++ b/molo/surveys/rules.py
@@ -327,6 +327,11 @@ class GroupMembershipRule(AbstractBaseRule):
         # Check whether user is part of a group
         return user.segment_groups.filter(id=self.group_id).exists()
 
+    def get_column_header(self):
+        return self.group.name
+
+    def get_user_info_string(self, user):
+        return str(user.segment_groups.filter(id=self.group_id).exists())
 
 class ArticleTagRule(AbstractBaseRule):
     static = True

--- a/molo/surveys/rules.py
+++ b/molo/surveys/rules.py
@@ -243,6 +243,22 @@ class SurveySubmissionDataRule(AbstractBaseRule):
             )
         }
 
+    def get_column_header(self):
+        try:
+            field_name = self.get_expected_field().label
+        except self.field_model.DoesNotExist:
+            field_name = self.field_name
+
+        return '%s - %s' % (self.survey, field_name)
+
+    def get_user_info_string(self, user):
+        survey_submission = self.get_survey_submission_of_user(user)
+
+        user_response = survey_submission.get_data().get(self.field_name)
+        if isinstance(user_response, list):
+            user_response = ", ".join(user_response)
+        return str(user_response)
+
 
 class SurveyResponseRule(AbstractBaseRule):
     static = True

--- a/molo/surveys/rules.py
+++ b/molo/surveys/rules.py
@@ -4,7 +4,7 @@ from django import forms
 from django.apps import apps
 from django.core.exceptions import ValidationError
 from django.db import models
-from django.utils import six
+from django.utils import six, timezone
 from django.utils.functional import cached_property
 from django.utils.translation import ugettext_lazy as _
 
@@ -280,6 +280,20 @@ class SurveyResponseRule(AbstractBaseRule):
                 self.survey,
             )
         }
+
+    def get_column_header(self):
+        return self.survey.title
+
+    def get_user_info_string(self, user):
+        submission_class = self.survey.get_submission_class()
+        submission = submission_class.objects.filter(
+            user=user,
+            page=self.survey,
+        ).last()
+        response_date = submission.created_at
+        if timezone.is_naive(response_date):
+            response_date = timezone.make_aware(related_field_value)
+        return response_date.strftime("%Y-%m-%d %H:%M")
 
 
 class GroupMembershipRule(AbstractBaseRule):

--- a/molo/surveys/rules.py
+++ b/molo/surveys/rules.py
@@ -312,7 +312,7 @@ class SurveyResponseRule(AbstractBaseRule):
         ).last()
         response_date = submission.created_at
         if timezone.is_naive(response_date):
-            response_date = timezone.make_aware(related_field_value)
+            response_date = timezone.make_aware(response_date)
         return response_date.strftime("%Y-%m-%d %H:%M")
 
 
@@ -352,6 +352,7 @@ class GroupMembershipRule(AbstractBaseRule):
 
     def get_user_info_string(self, user):
         return str(user.segment_groups.filter(id=self.group_id).exists())
+
 
 class ArticleTagRule(AbstractBaseRule):
     static = True
@@ -488,6 +489,7 @@ class ArticleTagRule(AbstractBaseRule):
             self.date_to,
         )
         return str(visit_count)
+
 
 class CombinationRule(AbstractBaseRule):
     body = blocks.StreamField([

--- a/molo/surveys/rules.py
+++ b/molo/surveys/rules.py
@@ -471,6 +471,23 @@ class ArticleTagRule(AbstractBaseRule):
             ),
         }
 
+    def get_column_header(self):
+        return 'Article Tag = %s' % self.tag.title
+
+    def get_user_info_string(self, user):
+        # Create a fake request so we can use the adapter
+        request = RequestFactory().get('/')
+        request.session = SessionStore()
+        request.user = user
+
+        from wagtail_personalisation.adapters import get_segment_adapter
+        adapter = get_segment_adapter(request)
+        visit_count = adapter.get_tag_count(
+            self.tag,
+            self.date_from,
+            self.date_to,
+        )
+        return str(visit_count)
 
 class CombinationRule(AbstractBaseRule):
     body = blocks.StreamField([

--- a/molo/surveys/tests/test_rules.py
+++ b/molo/surveys/tests/test_rules.py
@@ -587,3 +587,20 @@ class TestArticleTagRuleSegmentation(TestCase, MoloTestCaseMixin):
         )
         self.adapter.add_page_visit(self.article)
         self.assertFalse(rule.test_user(None))
+
+    def test_get_column_header(self):
+        rule = ArticleTagRule(
+            tag=self.tag,
+            count=0,
+            operator=ArticleTagRule.GREATER_THAN,
+        )
+        self.assertEqual(rule.get_column_header(), 'Article Tag = test')
+
+    def test_get_user_info_returns_true(self):
+        rule = ArticleTagRule(
+            tag=self.tag,
+            count=0,
+            operator=ArticleTagRule.GREATER_THAN,
+        )
+        self.adapter.add_page_visit(self.article)
+        self.assertEqual(rule.get_user_info_string(self.request.user), '1')

--- a/molo/surveys/tests/test_rules.py
+++ b/molo/surveys/tests/test_rules.py
@@ -212,14 +212,14 @@ class TestSurveyDataRuleSegmentation(TestCase, MoloTestCaseMixin):
         self.request.user = AnonymousUser()
         self.assertFalse(rule.test_user(self.request))
 
-    def test_test_user_without_request(self):
+    def test_call_test_user_without_request(self):
         rule = SurveySubmissionDataRule(
             survey=self.survey, operator=SurveySubmissionDataRule.CONTAINS,
             expected_response='er ra',
             field_name=self.singleline_text.clean_name)
         self.assertTrue(rule.test_user(None, self.request.user))
 
-    def test_test_user_without_user_or_request(self):
+    def test_call_test_user_without_user_or_request(self):
         rule = SurveySubmissionDataRule(
             survey=self.survey, operator=SurveySubmissionDataRule.CONTAINS,
             expected_response='er ra',
@@ -292,12 +292,12 @@ class TestSurveyResponseRule(TestCase, MoloTestCaseMixin):
         self.request.user = new_user
         self.assertTrue(rule.test_user(self.request))
 
-    def test_test_user_without_request(self):
+    def test_call_test_user_without_request(self):
         self.submit_survey(self.survey, self.user)
         rule = SurveyResponseRule(survey=self.survey)
         self.assertTrue(rule.test_user(None, self.request.user))
 
-    def test_test_user_without_user_or_request(self):
+    def test_call_test_user_without_user_or_request(self):
         self.submit_survey(self.survey, self.user)
         rule = SurveyResponseRule(survey=self.survey)
         self.assertFalse(rule.test_user(None))
@@ -338,11 +338,11 @@ class TestGroupMembershipRuleSegmentation(TestCase, MoloTestCaseMixin):
 
         self.assertFalse(rule.test_user(self.request))
 
-    def test_test_user_without_request(self):
+    def test_call_test_user_without_request(self):
         rule = GroupMembershipRule(group=self.group)
         self.assertTrue(rule.test_user(None, self.request.user))
 
-    def test_test_user_without_user_or_request(self):
+    def test_call_test_user_without_user_or_request(self):
         rule = GroupMembershipRule(group=self.group)
         self.assertFalse(rule.test_user(None))
 

--- a/molo/surveys/tests/test_rules.py
+++ b/molo/surveys/tests/test_rules.py
@@ -569,3 +569,21 @@ class TestArticleTagRuleSegmentation(TestCase, MoloTestCaseMixin):
     def test_visting_non_tagged_page_isnt_error(self):
         self.adapter.add_page_visit(self.main)
         self.assertFalse(self.request.session['tag_count'])
+
+    def test_call_test_user_without_request(self):
+        rule = ArticleTagRule(
+            tag=self.tag,
+            count=0,
+            operator=ArticleTagRule.GREATER_THAN,
+        )
+        self.adapter.add_page_visit(self.article)
+        self.assertTrue(rule.test_user(None, self.request.user))
+
+    def test_call_test_user_without_user_or_request(self):
+        rule = ArticleTagRule(
+            tag=self.tag,
+            count=0,
+            operator=ArticleTagRule.GREATER_THAN,
+        )
+        self.adapter.add_page_visit(self.article)
+        self.assertFalse(rule.test_user(None))

--- a/molo/surveys/tests/test_rules.py
+++ b/molo/surveys/tests/test_rules.py
@@ -226,6 +226,59 @@ class TestSurveyDataRuleSegmentation(TestCase, MoloTestCaseMixin):
             field_name=self.singleline_text.clean_name)
         self.assertFalse(rule.test_user(None))
 
+    def test_get_column_header(self):
+        rule = SurveySubmissionDataRule(
+            survey=self.survey, operator=SurveySubmissionDataRule.CONTAINS,
+            expected_response='er ra',
+            field_name=self.singleline_text.clean_name)
+
+        self.assertEqual(rule.get_column_header(), 'Test Survey - Singleline Text')
+
+    def test_get_user_info_string_returns_string_fields(self):
+        rule = SurveySubmissionDataRule(
+            survey=self.survey, operator=SurveySubmissionDataRule.CONTAINS,
+            expected_response='er ra',
+            field_name=self.singleline_text.clean_name)
+
+        self.assertEqual(rule.get_user_info_string(self.request.user),
+                         'super random text')
+
+    def test_get_user_info_string_returns_checkboxes_fields(self):
+        rule = SurveySubmissionDataRule(
+            survey=self.survey, operator=SurveySubmissionDataRule.CONTAINS,
+            expected_response='choice1',
+            field_name=self.checkboxes.clean_name)
+
+        self.assertEqual(rule.get_user_info_string(self.request.user),
+                         'choice 3, choice 1')
+
+    def test_get_user_info_string_returns_checkbox_fields(self):
+        rule = SurveySubmissionDataRule(
+            survey=self.survey, operator=SurveySubmissionDataRule.CONTAINS,
+            expected_response='1',
+            field_name=self.checkbox.clean_name)
+
+        self.assertEqual(rule.get_user_info_string(self.request.user),
+                         'True')
+
+    def test_get_user_info_string_returns_number_fields(self):
+        rule = SurveySubmissionDataRule(
+            survey=self.survey, operator=SurveySubmissionDataRule.CONTAINS,
+            expected_response='5',
+            field_name=self.number.clean_name)
+
+        self.assertEqual(rule.get_user_info_string(self.request.user),
+                         '5')
+
+    def test_get_user_info_string_returns_positive_number_fields(self):
+        rule = SurveySubmissionDataRule(
+            survey=self.survey, operator=SurveySubmissionDataRule.CONTAINS,
+            expected_response='8',
+            field_name=self.positive_number.clean_name)
+
+        self.assertEqual(rule.get_user_info_string(self.request.user),
+                         '8')
+
 
 class TestSurveyResponseRule(TestCase, MoloTestCaseMixin):
     def setUp(self):

--- a/molo/surveys/tests/test_rules.py
+++ b/molo/surveys/tests/test_rules.py
@@ -232,7 +232,8 @@ class TestSurveyDataRuleSegmentation(TestCase, MoloTestCaseMixin):
             expected_response='er ra',
             field_name=self.singleline_text.clean_name)
 
-        self.assertEqual(rule.get_column_header(), 'Test Survey - Singleline Text')
+        self.assertEqual(rule.get_column_header(),
+                         'Test Survey - Singleline Text')
 
     def test_get_user_info_string_returns_string_fields(self):
         rule = SurveySubmissionDataRule(

--- a/molo/surveys/tests/test_rules.py
+++ b/molo/surveys/tests/test_rules.py
@@ -302,6 +302,16 @@ class TestSurveyResponseRule(TestCase, MoloTestCaseMixin):
         rule = SurveyResponseRule(survey=self.survey)
         self.assertFalse(rule.test_user(None))
 
+    def test_get_column_header(self):
+        rule = SurveyResponseRule(survey=self.survey)
+        self.assertEqual(rule.get_column_header(), 'Other Survey')
+
+    def test_get_user_info_returns_submission_date(self):
+        current_date = datetime.datetime.now().strftime("%Y-%m-%d %H:%M")
+        self.submit_survey(self.survey, self.user)
+        rule = SurveyResponseRule(survey=self.survey)
+        self.assertEqual(rule.get_user_info_string(self.user), current_date)
+
 
 class TestGroupMembershipRuleSegmentation(TestCase, MoloTestCaseMixin):
     def setUp(self):

--- a/molo/surveys/tests/test_rules.py
+++ b/molo/surveys/tests/test_rules.py
@@ -356,6 +356,14 @@ class TestGroupMembershipRuleSegmentation(TestCase, MoloTestCaseMixin):
         rule = GroupMembershipRule(group=self.group)
         self.assertFalse(rule.test_user(None))
 
+    def test_get_column_header(self):
+        rule = GroupMembershipRule(group=self.group)
+        self.assertEqual(rule.get_column_header(), 'Super Test Group!')
+
+    def test_get_user_info_returns_true(self):
+        rule = GroupMembershipRule(group=self.group)
+        self.assertEqual(rule.get_user_info_string(self.request.user), 'True')
+
 
 class TestArticleTagRuleSegmentation(TestCase, MoloTestCaseMixin):
     def setUp(self):


### PR DESCRIPTION
In order to show how a user matched the rules of a segment we need to get the user's data for each rule. Only the rule knows which field must be retrieved and what it should be called.
These methods will be called when compiling a csv of the users that matched a static segments rules.

This adds methods for getting that data to the Survey Response, Survey Submission Data, Group Membership and Article tag rules.
This also allows the article tag rule to be tested against a user rather than a request.