### PR TITLE
Parse natural language dates

### DIFF
--- a/molo/surveys/forms.py
+++ b/molo/surveys/forms.py
@@ -14,6 +14,7 @@ from wagtail.wagtailadmin.forms import WagtailAdminPageForm
 from wagtailsurveys.forms import FormBuilder
 
 from .blocks import SkipState, VALID_SKIP_LOGIC, VALID_SKIP_SELECTORS
+from .widgets import NaturalDateInput
 
 
 class CharacterCountWidget(forms.TextInput):
@@ -48,6 +49,11 @@ class SurveysFormBuilder(FormBuilder):
     def create_multiline_field(self, field, options):
         options['widget'] = MultiLineWidget
         return forms.CharField(**options)
+
+    def create_date_field(self, field, options):
+        options['widget'] = NaturalDateInput
+        return super(
+            SurveysFormBuilder, self).create_date_field(field, options)
 
     def create_positive_number_field(self, field, options):
         return forms.DecimalField(min_value=0, **options)

--- a/molo/surveys/tests/test_widgets.py
+++ b/molo/surveys/tests/test_widgets.py
@@ -1,0 +1,50 @@
+from datetime import datetime
+
+from django.test import TestCase
+
+from mock import patch
+
+from molo.surveys.widgets import NaturalDateInput
+
+
+class TestNaturalDateInputWidget(TestCase):
+    def setUp(self):
+        self.widget = NaturalDateInput()
+
+    def test_widget_returns_value_if_falsey(self):
+        data = {'name': ''}
+
+        self.assertEqual(
+            self.widget.value_from_datadict(data, None, 'name'),
+            '',
+        )
+
+    def test_uses_dateparser_to_parse_dates(self):
+        data = {'name': '1 January 2018'}
+
+        self.assertEqual(
+            self.widget.value_from_datadict(data, None, 'name'),
+            datetime(2018, 1, 1),
+        )
+
+    @patch('molo.surveys.widgets.NaturalDateInput._parse_date')
+    def test_caches_expensive_result_of_dateparser(self, parse_date_mock):
+        parse_date_mock.return_value = datetime(2018, 1, 1)
+        data = {'name': '1 January 2018'}
+
+        self.widget.value_from_datadict(data, None, 'name')
+        self.widget.value_from_datadict(data, None, 'name')
+
+        self.assertEqual(parse_date_mock.call_count, 1)
+
+    @patch('molo.surveys.widgets.NaturalDateInput._parse_date')
+    def test_return_original_if_dateparser_returns_none(self, parse_date_mock):
+        parse_date_mock.return_value = None
+        data = {'name': "rubbish value which can't be parsed as a date"}
+
+        self.widget.value_from_datadict(data, None, 'name')
+
+        self.assertEqual(
+            self.widget.value_from_datadict(data, None, 'name'),
+            "rubbish value which can't be parsed as a date",
+        )

--- a/molo/surveys/widgets.py
+++ b/molo/surveys/widgets.py
@@ -1,0 +1,32 @@
+from dateparser import parse as date_parse
+
+from django.core.cache import cache
+from django.forms import DateInput
+
+from hashlib import md5
+
+
+class NaturalDateInput(DateInput):
+    def _parse_date(self, date_string):
+        return date_parse(date_string)
+
+    def value_from_datadict(self, data, files, name):
+        date = data.get(name)
+
+        if not date:
+            return date
+
+        hasher = md5()
+        hasher.update(date.encode('utf-8'))
+        cache_key = 'date_parse_{0}'.format(hasher.hexdigest())
+
+        parsed_date = cache.get(cache_key)
+
+        if not parsed_date:
+            parsed_date = self._parse_date(date)
+            cache.set(cache_key, parsed_date, None)
+
+        if parsed_date is None:
+            return date
+        else:
+            return parsed_date

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 molo.core<7.0.0,>=6.5.0
 celery<4.0
+dateparser>=0.7.0,<0.8.0
 django-celery
 wagtailsurveys==0.1.1
 wagtail-personalisation-molo==0.10.7


### PR DESCRIPTION
Currently you have to input a date in a survey precisely matching the Django INPUT_FORMATS.

This commit uses dateparser to process a date which somebody enters as natural language.

It looks like it performs adequate sanitisation of user input.

The parsing is quite expensive and the Django docs recommend to implement caching on `value_from_datadict()` because it can be called multiple times in one request, so I've done that.