### PR TITLE
Fix survey segmentation rules

### DIFF
--- a/molo/surveys/rules.py
+++ b/molo/surveys/rules.py
@@ -256,9 +256,20 @@ class SurveySubmissionDataRule(AbstractBaseRule):
         return '%s - %s' % (self.survey, field_name)
 
     def get_user_info_string(self, user):
-        survey_submission = self.get_survey_submission_of_user(user)
+        try:
+            survey_submission = self.get_survey_submission_of_user(user)
+        except self.survey_submission_model.DoesNotExist:
+            # No survey found so return false
+            return "No submission"
+        except self.survey_submission_model.MultipleObjectsReturned:
+            # There should not be two survey submissions, but just in case
+            # let's return false since we don't want to be guessing what user
+            # meant in their response.
+            return "Too many submissions"
 
         user_response = survey_submission.get_data().get(self.field_name)
+        if not user_response:
+            return "Not answered"
         if isinstance(user_response, list):
             user_response = ", ".join(user_response)
         return str(user_response)
@@ -310,6 +321,8 @@ class SurveyResponseRule(AbstractBaseRule):
             user=user,
             page=self.survey,
         ).last()
+        if not submission:
+            return "No submission"
         response_date = submission.created_at
         if timezone.is_naive(response_date):
             response_date = timezone.make_aware(response_date)

--- a/molo/surveys/rules.py
+++ b/molo/surveys/rules.py
@@ -99,7 +99,7 @@ class SurveySubmissionDataRule(AbstractBaseRule):
 
     @cached_property
     def field_model(self):
-        return apps.get_model('personalise', 'PersonalisableSurveyFormField')
+        return apps.get_model('surveys', 'PersonalisableSurveyFormField')
 
     @property
     def survey_submission_model(self):

--- a/molo/surveys/tests/test_rules.py
+++ b/molo/surveys/tests/test_rules.py
@@ -59,9 +59,12 @@ class TestSurveyDataRuleSegmentation(TestCase, MoloTestCaseMixin):
         self.positive_number = PersonalisableSurveyFormField.objects.create(
             field_type='positive_number', label='Positive Number Field',
             page=self.survey)
+        self.not_required_number = PersonalisableSurveyFormField.objects.create(
+            field_type='number', label='Not Required Field', page=self.survey,
+            required=False)
 
         # Create survey submission
-        data = {
+        self.data = {
             self.singleline_text.clean_name: 'super random text',
             self.checkboxes.clean_name: ['choice 3', 'choice 1'],
             self.checkbox.clean_name: True,
@@ -70,7 +73,7 @@ class TestSurveyDataRuleSegmentation(TestCase, MoloTestCaseMixin):
 
         }
         form = self.survey.get_form(
-            data, page=self.survey, user=self.request.user)
+            self.data, page=self.survey, user=self.request.user)
 
         assert form.is_valid(), \
             'Could not validate submission form. %s' % repr(form.errors)
@@ -199,6 +202,29 @@ class TestSurveyDataRuleSegmentation(TestCase, MoloTestCaseMixin):
 
         self.assertFalse(rule.test_user(self.request))
 
+    def test_passing_not_required_rule(self):
+        self.data.update({self.not_required_number.clean_name: 5})
+        form = self.survey.get_form(
+            self.data, page=self.survey, user=self.request.user)
+        assert form.is_valid(), \
+            'Could not validate submission form. %s' % repr(form.errors)
+        self.survey.process_form_submission(form)
+
+        rule = SurveySubmissionDataRule(
+            survey=self.survey, operator=SurveySubmissionDataRule.CONTAINS,
+            expected_response='5',
+            field_name=self.not_required_number.clean_name)
+
+        self.assertFalse(rule.test_user(self.request))
+
+    def test_failing_not_required_rule(self):
+        rule = SurveySubmissionDataRule(
+            survey=self.survey, operator=SurveySubmissionDataRule.CONTAINS,
+            expected_response='4',
+            field_name=self.not_required_number.clean_name)
+
+        self.assertFalse(rule.test_user(self.request))
+
     def test_not_logged_in_user_fails(self):
         rule = SurveySubmissionDataRule(
             survey=self.survey, operator=SurveySubmissionDataRule.CONTAINS,
@@ -279,6 +305,41 @@ class TestSurveyDataRuleSegmentation(TestCase, MoloTestCaseMixin):
 
         self.assertEqual(rule.get_user_info_string(self.request.user),
                          '8')
+
+    def test_get_user_info_string_returns_if_no_submission(self):
+        user = get_user_model().objects.create_user(
+            username='another', email='another@example.com', password='another')
+        rule = SurveySubmissionDataRule(
+            survey=self.survey, operator=SurveySubmissionDataRule.CONTAINS,
+            expected_response='8',
+            field_name=self.positive_number.clean_name)
+    
+        self.assertEqual(rule.get_user_info_string(user),
+                         'No submission')
+    
+    def test_get_user_info_string_returns_if_multiple_submissions(self):
+        form = self.survey.get_form(
+            self.data, page=self.survey, user=self.request.user)
+        assert form.is_valid(), \
+            'Could not validate submission form. %s' % repr(form.errors)
+        self.survey.process_form_submission(form)
+    
+        rule = SurveySubmissionDataRule(
+            survey=self.survey, operator=SurveySubmissionDataRule.CONTAINS,
+            expected_response='8',
+            field_name=self.positive_number.clean_name)
+    
+        self.assertEqual(rule.get_user_info_string(self.request.user),
+                         'Too many submissions')
+
+    def test_get_user_info_string_returns_if_field_not_answered(self):
+        rule = SurveySubmissionDataRule(
+            survey=self.survey, operator=SurveySubmissionDataRule.CONTAINS,
+            expected_response='4',
+            field_name=self.not_required_number.clean_name)
+
+        self.assertEqual(rule.get_user_info_string(self.request.user),
+                         'Not answered')
 
 
 class TestSurveyResponseRule(TestCase, MoloTestCaseMixin):
@@ -365,6 +426,10 @@ class TestSurveyResponseRule(TestCase, MoloTestCaseMixin):
         self.submit_survey(self.survey, self.user)
         rule = SurveyResponseRule(survey=self.survey)
         self.assertEqual(rule.get_user_info_string(self.user), current_date)
+
+    def test_get_user_info_returns_if_no_submission(self):
+        rule = SurveyResponseRule(survey=self.survey)
+        self.assertEqual(rule.get_user_info_string(self.user), "No submission")
 
 
 class TestGroupMembershipRuleSegmentation(TestCase, MoloTestCaseMixin):

--- a/molo/surveys/tests/test_rules.py
+++ b/molo/surveys/tests/test_rules.py
@@ -59,7 +59,7 @@ class TestSurveyDataRuleSegmentation(TestCase, MoloTestCaseMixin):
         self.positive_number = PersonalisableSurveyFormField.objects.create(
             field_type='positive_number', label='Positive Number Field',
             page=self.survey)
-        self.not_required_number = PersonalisableSurveyFormField.objects.create(
+        self.not_required_field = PersonalisableSurveyFormField.objects.create(
             field_type='number', label='Not Required Field', page=self.survey,
             required=False)
 
@@ -210,7 +210,7 @@ class TestSurveyDataRuleSegmentation(TestCase, MoloTestCaseMixin):
         self.assertFalse(rule.test_user(self.request))
 
     def test_passing_not_required_rule(self):
-        self.data.update({self.not_required_number.clean_name: 5})
+        self.data.update({self.not_required_field.clean_name: 5})
         form = self.survey.get_form(
             self.data, page=self.survey, user=self.request.user)
         assert form.is_valid(), \
@@ -220,7 +220,7 @@ class TestSurveyDataRuleSegmentation(TestCase, MoloTestCaseMixin):
         rule = SurveySubmissionDataRule(
             survey=self.survey, operator=SurveySubmissionDataRule.CONTAINS,
             expected_response='5',
-            field_name=self.not_required_number.clean_name)
+            field_name=self.not_required_field.clean_name)
 
         self.assertFalse(rule.test_user(self.request))
 
@@ -228,7 +228,7 @@ class TestSurveyDataRuleSegmentation(TestCase, MoloTestCaseMixin):
         rule = SurveySubmissionDataRule(
             survey=self.survey, operator=SurveySubmissionDataRule.CONTAINS,
             expected_response='4',
-            field_name=self.not_required_number.clean_name)
+            field_name=self.not_required_field.clean_name)
 
         self.assertFalse(rule.test_user(self.request))
 
@@ -315,27 +315,28 @@ class TestSurveyDataRuleSegmentation(TestCase, MoloTestCaseMixin):
 
     def test_get_user_info_string_returns_if_no_submission(self):
         user = get_user_model().objects.create_user(
-            username='another', email='another@example.com', password='another')
+            username='another', email='another@example.com',
+            password='another')
         rule = SurveySubmissionDataRule(
             survey=self.survey, operator=SurveySubmissionDataRule.CONTAINS,
             expected_response='8',
             field_name=self.positive_number.clean_name)
-    
+
         self.assertEqual(rule.get_user_info_string(user),
                          'No submission')
-    
+
     def test_get_user_info_string_returns_if_multiple_submissions(self):
         form = self.survey.get_form(
             self.data, page=self.survey, user=self.request.user)
         assert form.is_valid(), \
             'Could not validate submission form. %s' % repr(form.errors)
         self.survey.process_form_submission(form)
-    
+
         rule = SurveySubmissionDataRule(
             survey=self.survey, operator=SurveySubmissionDataRule.CONTAINS,
             expected_response='8',
             field_name=self.positive_number.clean_name)
-    
+
         self.assertEqual(rule.get_user_info_string(self.request.user),
                          'Too many submissions')
 
@@ -343,7 +344,7 @@ class TestSurveyDataRuleSegmentation(TestCase, MoloTestCaseMixin):
         rule = SurveySubmissionDataRule(
             survey=self.survey, operator=SurveySubmissionDataRule.CONTAINS,
             expected_response='4',
-            field_name=self.not_required_number.clean_name)
+            field_name=self.not_required_field.clean_name)
 
         self.assertEqual(rule.get_user_info_string(self.request.user),
                          'Not answered')

--- a/molo/surveys/tests/test_rules.py
+++ b/molo/surveys/tests/test_rules.py
@@ -82,6 +82,13 @@ class TestSurveyDataRuleSegmentation(TestCase, MoloTestCaseMixin):
 
         self.survey.refresh_from_db()
 
+    def test_get_field_model(self):
+        rule = SurveySubmissionDataRule(
+            survey=self.survey, operator=SurveySubmissionDataRule.EQUALS,
+            expected_response='super random text',
+            field_name=self.singleline_text.clean_name)
+        self.assertEqual(rule.field_model, PersonalisableSurveyFormField)
+
     def test_survey_data_rule_is_static(self):
         rule = SurveySubmissionDataRule(
             survey=self.survey, operator=SurveySubmissionDataRule.EQUALS,


### PR DESCRIPTION
When trying to create a segment containing a SurveySubmissionRule the server is returning an internal server error because the `field_model` method is using the incorrect app.

`get_user_info_string` should not assume the user has already matched the segment (otherwise they cause errors when trying to download the user data for Match Any segments)