### PR TITLE
Feature/max length validation messages

### DIFF
--- a/molo/surveys/forms.py
+++ b/molo/surveys/forms.py
@@ -17,6 +17,9 @@ from .blocks import SkipState, VALID_SKIP_LOGIC, VALID_SKIP_SELECTORS
 from .widgets import NaturalDateInput
 
 
+CHARACTER_COUNT_CHOICE_LIMIT = 512
+
+
 class CharacterCountWidget(forms.TextInput):
     class Media:
         js = ('js/widgets/character_count.js',)
@@ -29,6 +32,50 @@ class CharacterCountWidget(forms.TextInput):
             super(CharacterCountWidget, self).render(name, value, attrs),
             maximum_text,
         )
+
+
+class CharacterCountMixin(object):
+    max_length = CHARACTER_COUNT_CHOICE_LIMIT
+
+    def __init__(self, *args, **kwargs):
+        self.max_length = kwargs.pop('max_length', self.max_length)
+        super(CharacterCountMixin, self).__init__(*args, **kwargs)
+
+        self.error_messages['max_length'] = _(
+            'This field can not be more than {max_length} characters long'
+        ).format(max_length=self.max_length)
+
+    def validate(self, value):
+        super(CharacterCountMixin, self).validate(value)
+        if len(value) > self.max_length:
+            raise ValidationError(
+                self.error_messages['max_length'],
+                code='max_length', params={'value': value},
+            )
+
+
+class CharacterCountMultipleChoiceField(
+    CharacterCountMixin, forms.MultipleChoiceField
+):
+    """ Limit character count for Multi choice fields """
+
+
+class CharacterCountChoiceField(
+    CharacterCountMixin, forms.ChoiceField
+):
+    """ Limit character count for choice fields """
+
+
+class CharacterCountCheckboxSelectMultiple(
+    CharacterCountMixin, forms.CheckboxSelectMultiple
+):
+    """ Limit character count for checkbox fields """
+
+
+class CharacterCountCheckboxInput(
+    CharacterCountMixin, forms.CheckboxInput
+):
+    """ Limit character count for checkbox fields """
 
 
 class MultiLineWidget(forms.Textarea):
@@ -63,6 +110,24 @@ class SurveysFormBuilder(FormBuilder):
     def create_positive_number_field(self, field, options):
         return forms.DecimalField(min_value=0, **options)
 
+    def create_dropdown_field(self, field, options):
+        options['choices'] = map(
+            lambda x: (x.strip(), x.strip()),
+            field.choices.split(','))
+        return CharacterCountChoiceField(**options)
+
+    def create_radio_field(self, field, options):
+        options['choices'] = map(
+            lambda x: (x.strip(), x.strip()),
+            field.choices.split(','))
+        return CharacterCountChoiceField(widget=forms.RadioSelect, **options)
+
+    def create_checkboxes_field(self, field, options):
+        options['choices'] = [(x.strip(), x.strip()) for x in field.choices.split(',')]
+        options['initial'] = [x.strip() for x in field.default_value.split(',')]
+        return CharacterCountMultipleChoiceField(
+            widget=forms.CheckboxSelectMultiple, **options)
+
     @property
     def formfields(self):
         '''
@@ -76,7 +141,6 @@ class SurveysFormBuilder(FormBuilder):
 
         for field in self.fields:
             options = self.get_field_options(field)
-
             if field.field_type in self.FIELD_TYPES:
                 method = getattr(self,
                                  self.FIELD_TYPES[field.field_type].__name__)
@@ -163,6 +227,7 @@ class CSVGroupCreationForm(forms.ModelForm):
 
 
 class BaseMoloSurveyForm(WagtailAdminPageForm):
+
     def clean(self):
         cleaned_data = super(BaseMoloSurveyForm, self).clean()
 

--- a/molo/surveys/forms.py
+++ b/molo/surveys/forms.py
@@ -123,8 +123,12 @@ class SurveysFormBuilder(FormBuilder):
         return CharacterCountChoiceField(widget=forms.RadioSelect, **options)
 
     def create_checkboxes_field(self, field, options):
-        options['choices'] = [(x.strip(), x.strip()) for x in field.choices.split(',')]
-        options['initial'] = [x.strip() for x in field.default_value.split(',')]
+        options['choices'] = [
+            (x.strip(), x.strip()) for x in field.choices.split(',')
+        ]
+        options['initial'] = [
+            x.strip() for x in field.default_value.split(',')
+        ]
         return CharacterCountMultipleChoiceField(
             widget=forms.CheckboxSelectMultiple, **options)
 

--- a/molo/surveys/models.py
+++ b/molo/surveys/models.py
@@ -49,6 +49,7 @@ from .forms import (  # noqa
     MoloSurveyForm,
     PersonalisableMoloSurveyForm,
     SurveysFormBuilder,
+    CHARACTER_COUNT_CHOICE_LIMIT,
 )
 from .rules import (  # noqa
     ArticleTagRule,
@@ -549,6 +550,13 @@ class MoloSurveyFormField(SkipLogicMixin, AdminLabelMixin,
                 if not isinstance(parsed_date, datetime.datetime):
                     raise ValidationError(
                         {'default_value': ["Must be a valid date", ]})
+
+        if self.choices and len(self.choices) > CHARACTER_COUNT_CHOICE_LIMIT:
+            raise ValidationError(
+                {'field_type': _(
+                    'The maximum character(s) limit exceeded ({max_limit}). '
+                ).format(max_limit=CHARACTER_COUNT_CHOICE_LIMIT)}
+            )
 
 
 surveys_models.AbstractFormField.panels[4] = SkipLogicStreamPanel('skip_logic')

--- a/molo/surveys/models.py
+++ b/molo/surveys/models.py
@@ -554,7 +554,8 @@ class MoloSurveyFormField(SkipLogicMixin, AdminLabelMixin,
         if self.choices and len(self.choices) > CHARACTER_COUNT_CHOICE_LIMIT:
             raise ValidationError(
                 {'field_type': _(
-                    'The maximum character(s) limit exceeded ({max_limit}). '
+                    'The combined choices\' maximum characters'
+                    ' limit has been exceeded ({max_limit} character(s)).'
                 ).format(max_limit=CHARACTER_COUNT_CHOICE_LIMIT)}
             )
 


### PR DESCRIPTION
Add a 512 character limit for survey options
* Added model choices validation to effectively be the default error shown in the admin
* Also added front end validation as another safe guard for choice fields