### PR TITLE
redirect user to translated page if language changed when on survey

### DIFF
--- a/molo/surveys/models.py
+++ b/molo/surveys/models.py
@@ -286,6 +286,13 @@ class MoloSurveyPage(
         When the last step is submitted correctly, the whole form is saved in
         the DB.
         """
+        context = self.get_context(request)
+        # this will only return a page if there is a translation
+        page = context['page'].get_translation_for(
+            locale=request.LANGUAGE_CODE, site=request.site)
+        if page:
+            # if there is a translation, redirect to the translated page
+            return redirect(page.url)
         survey_data = self.load_data(request)
 
         paginator = SkipLogicPaginator(
@@ -366,7 +373,7 @@ class MoloSurveyPage(
             # Create empty form for non-POST requests
             form_class = self.get_form_class_for_step(step)
             form = form_class(page=self, user=request.user)
-        context = self.get_context(request)
+
         context['form'] = form
         context['fields_step'] = step
         context['is_intermediate_step'] = step.possibly_has_next()

--- a/molo/surveys/tests/test_views.py
+++ b/molo/surveys/tests/test_views.py
@@ -2,7 +2,7 @@ import json
 from bs4 import BeautifulSoup
 from django.contrib.auth import get_user_model
 from django.core.urlresolvers import reverse
-from django.test import TestCase
+from django.test import TestCase, RequestFactory
 from django.test.client import Client
 from django.utils.text import slugify
 from molo.core.models import Languages, Main, SiteLanguageRelation
@@ -374,6 +374,31 @@ class TestSurveyViews(TestCase, MoloTestCaseMixin):
             '<h2><a href="/admin/surveys/submissions/%s/">'
             'Test Survey</a></h2>' % molo_survey_page.pk)
 
+    def test_changing_languages_changes_survey(self):
+        # Create a survey
+        self.user = self.login()
+        molo_survey_page, molo_survey_form_field = \
+            self.create_molo_survey_page_with_field(parent=self.surveys_index)
+        # Create a translated survey
+        response = self.client.post(reverse(
+            'add_translation', args=[molo_survey_page.id, 'fr']))
+        translated_survey = MoloSurveyPage.objects.get(
+            slug='french-translation-of-test-survey')
+        translated_survey.save_revision().publish()
+        create_molo_survey_formfield(
+            survey=translated_survey, field_type='singleline',
+            label="Your favourite animal in french", required=True)
+
+        # when requesting the english survey with the french language code
+        # it should return the french survey
+        request = RequestFactory().get(molo_survey_page.url)
+        request.LANGUAGE_CODE = 'fr'
+        request.context = {'page': molo_survey_page}
+        request.site = self.main.get_site()
+        response = molo_survey_page.serve_questions(request)
+        self.assertEquals(response.status_code, 302)
+        self.assertEquals(response['location'], translated_survey.url)
+
     def test_can_see_translated_survey_submissions_in_admin(self):
         """ Test that submissions to translated surveys can be seen in the
             admin
@@ -686,6 +711,10 @@ class TestSkipLogicSurveyView(TestCase, MoloTestCaseMixin):
         self.english = SiteLanguageRelation.objects.create(
             language_setting=self.language_setting,
             locale='en',
+            is_active=True)
+        self.french = SiteLanguageRelation.objects.create(
+            language_setting=self.language_setting,
+            locale='fr',
             is_active=True)
 
         self.molo_survey_page = self.new_survey('Test Survey')

--- a/molo/surveys/tests/test_views.py
+++ b/molo/surveys/tests/test_views.py
@@ -712,10 +712,6 @@ class TestSkipLogicSurveyView(TestCase, MoloTestCaseMixin):
             language_setting=self.language_setting,
             locale='en',
             is_active=True)
-        self.french = SiteLanguageRelation.objects.create(
-            language_setting=self.language_setting,
-            locale='fr',
-            is_active=True)
 
         self.molo_survey_page = self.new_survey('Test Survey')
         self.another_molo_survey_page = self.new_survey('Another Test Survey')


### PR DESCRIPTION
When you are on a survey, and change the language, it does not show you the translated survey.

This PR redirects you to the translated survey if there is a translated page