### PR TITLE
Combine lists in submission data to strings so they are decoded

### DIFF
--- a/molo/surveys/models.py
+++ b/molo/surveys/models.py
@@ -612,6 +612,10 @@ class MoloSurveySubmission(surveys_models.AbstractFormSubmission):
 
     def get_data(self):
         form_data = super(MoloSurveySubmission, self).get_data()
+        for key, value in form_data.items():
+            # Convert lists to strings so they display properly in the view
+            if isinstance(value, list):
+                form_data[key] = u', '.join(value)
         form_data.update({
             'username': self.user.username if self.user else 'Anonymous',
         })

--- a/molo/surveys/rules.py
+++ b/molo/surveys/rules.py
@@ -214,6 +214,15 @@ class SurveySubmissionDataRule(AbstractBaseRule):
                 if self.operator == self.EQUALS:
                     return set(python_value) == set(user_response)
 
+            if isinstance(python_value, list) \
+                    and isinstance(user_response, six.string_types):
+                user_response = user_response.split(u', ')
+                if self.operator == self.CONTAINS:
+                    return set(python_value).issubset(user_response)
+
+                if self.operator == self.EQUALS:
+                    return set(python_value) == set(user_response)
+
             if isinstance(python_value, six.string_types) \
                     and isinstance(user_response, six.string_types):
                 if self.operator == self.CONTAINS:

--- a/molo/surveys/tests/test_models.py
+++ b/molo/surveys/tests/test_models.py
@@ -32,6 +32,13 @@ class TestSurveyModels(TestCase, MoloTestCaseMixin):
         ).get_data()
         self.assertIn('username', data)
 
+    def test_submission_class_get_data_converts_list_to_string(self):
+        data = MoloSurveyPage().get_submission_class()(
+            form_data='{"checkbox-question": ["option 1", "option 2"]}'
+        ).get_data()
+        self.assertIn('checkbox-question', data)
+        self.assertEqual(data['checkbox-question'], u"option 1, option 2")
+
 
 class TestSkipLogicMixin(TestCase, MoloTestCaseMixin):
     def setUp(self):

--- a/molo/surveys/tests/test_rules.py
+++ b/molo/surveys/tests/test_rules.py
@@ -129,9 +129,9 @@ class TestSurveyDataRuleSegmentation(TestCase, MoloTestCaseMixin):
 
         self.assertFalse(rule.test_user(self.request))
 
-    def test_padding_checkboxes_rule_with_equal_operator(self):
+    def test_passing_checkboxes_rule_with_equal_operator(self):
         rule = SurveySubmissionDataRule(
-            survey=self.survey, operator=SurveySubmissionDataRule.CONTAINS,
+            survey=self.survey, operator=SurveySubmissionDataRule.EQUALS,
             expected_response=' choice 3 , choice 1 ',
             field_name=self.checkboxes.clean_name)
 
@@ -139,7 +139,7 @@ class TestSurveyDataRuleSegmentation(TestCase, MoloTestCaseMixin):
 
     def test_failing_checkboxes_rule_with_equal_operator(self):
         rule = SurveySubmissionDataRule(
-            survey=self.survey, operator=SurveySubmissionDataRule.CONTAINS,
+            survey=self.survey, operator=SurveySubmissionDataRule.EQUALS,
             expected_response='choice2,choice1',
             field_name=self.checkboxes.clean_name)
 


### PR DESCRIPTION
This fix converts checkbox responses from a list to a string before returning the submission data.
This is necessary to ensure the contents of the list are decoded when the submission is displayed.