### PR TITLE
Allow entering field labels for survey submission rules

### DIFF
--- a/molo/surveys/rules.py
+++ b/molo/surveys/rules.py
@@ -11,6 +11,10 @@ from django.utils import six, timezone
 from django.utils.functional import cached_property
 from django.utils.translation import ugettext_lazy as _
 
+from django.utils.six import text_type
+from django.utils.text import slugify
+from unidecode import unidecode
+
 from wagtail.wagtailcore.blocks.stream_block import StreamBlockValidationError
 from wagtail.wagtailadmin.edit_handlers import (
     FieldPanel,
@@ -64,9 +68,7 @@ class SurveySubmissionDataRule(AbstractBaseRule):
                                on_delete=models.CASCADE)
     field_name = models.CharField(
         _('field name'), max_length=255,
-        help_text=_('Field\'s label in a lower-case '
-                    'format with spaces replaced by '
-                    'dashes. For possible choices '
+        help_text=_('Field\'s label. For possible choices '
                     'please input any text and save, '
                     'so it will be displayed in the '
                     'error messages below the '
@@ -153,13 +155,17 @@ class SurveySubmissionDataRule(AbstractBaseRule):
         if not self.survey_id:
             return
 
+        # Make sure field name is in correct format
+        self.field_name = str(slugify(text_type(unidecode(self.field_name))))
+
         # Make sure field name is a valid name
         field_names = [f.clean_name for f in self.survey.get_form_fields()]
 
         if self.field_name not in field_names:
+            field_labels = [f.label for f in self.survey.get_form_fields()]
             raise ValidationError({
                 'field_name': [_('You need to choose valid field name out '
-                                 'of: "%s".') % '", "'.join(field_names)]
+                                 'of: "%s".') % '", "'.join(field_labels)]
             })
 
         # Convert value from the rule into Python value.

--- a/molo/surveys/tests/test_rules.py
+++ b/molo/surveys/tests/test_rules.py
@@ -82,6 +82,40 @@ class TestSurveyDataRuleSegmentation(TestCase, MoloTestCaseMixin):
 
         self.survey.refresh_from_db()
 
+    def test_rule_validates_with_correct_field_name(self):
+        rule = SurveySubmissionDataRule(
+            survey=self.survey, operator=SurveySubmissionDataRule.EQUALS,
+            expected_response='super random text',
+            field_name='incorrect-field-name')
+
+        with self.assertRaises(ValidationError):
+            rule.clean()
+
+        rule.field_name = 'singleline-text'
+        try:
+            rule.clean()
+        except ValidationError:
+            self.fail(
+                "SurveySubmissionDataRule.clean()raised ValidationError!")
+
+    def test_rule_validates_with_correct_label_name(self):
+        rule = SurveySubmissionDataRule(
+            survey=self.survey, operator=SurveySubmissionDataRule.EQUALS,
+            expected_response='super random text',
+            field_name='Incorrect Field name!!')
+
+        with self.assertRaises(ValidationError):
+            rule.clean()
+
+        rule.field_name = 'Singleline Text'
+        try:
+            rule.clean()
+        except ValidationError:
+            self.fail(
+                "SurveySubmissionDataRule.clean()raised ValidationError!")
+        # check the field_name has been changed to the correct one
+        self.assertEqual(rule.field_name, 'singleline-text')
+
     def test_get_field_model(self):
         rule = SurveySubmissionDataRule(
             survey=self.survey, operator=SurveySubmissionDataRule.EQUALS,


### PR DESCRIPTION
Currently an admin has to enter the field name for a field in order to create a survey submission rule based on that field. This field name isn't always intuitive to the user. 
This change allows them to enter the field name or the label for the field.
It also displays the labels in the error message rather than the field names. This has the added side-effect of displaying labels for non-latin character sets instead of the encoded field names when displaying the error